### PR TITLE
Changed base to ubuntu as the alpine base results in a go error past …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM alpine:3.5
+FROM ubuntu:18.04
+RUN apt-get update && apt-get install -y golang-go
 
-ENV KRAKEND_VERSION 0.3.9
-RUN apk add --no-cache ca-certificates
+ENV KRAKEND_VERSION 0.5.0
 ADD http://repo.krakend.io/bin/krakend_${KRAKEND_VERSION}_amd64.tar.gz krakend_${KRAKEND_VERSION}_amd64.tar.gz
 RUN tar xvfz krakend_${KRAKEND_VERSION}_amd64.tar.gz
 
 VOLUME [ "/etc/krakend" ]
 
-ENTRYPOINT [ "/krakend" ]
+ENTRYPOINT [ "/usr/bin/krakend" ]
 CMD [ "run" ]
 
 EXPOSE 8080
+


### PR DESCRIPTION
…version 3.9.0. Updated KRAKEND_VERSION to 0.5.0. Updated executable path for krakend.

Had some issues with the current Dockerfile in the repository so I decided to update it based on several errors in which I had encountered when using versions > 0.3.9

The Ubuntu base may not be the best option but I am open to feedback for a more appropriate docker base.
